### PR TITLE
Basic CircleCI setup: Lint the codebase on all inbound PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,35 @@
+version: 2
+jobs:
+  lint:
+    docker:
+      - image: 'python:3.7'
+
+    environment:
+        KMK_TEST: 1
+        PIPENV_VENV_IN_PROJECT: 1
+
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-kmk-lint-{{ checksum "Pipfile.lock" }}
+
+      - run: pip install pipenv==2018.7.1
+      - run: pipenv install --dev
+      - run: pipenv run flake8
+
+      - save_cache:
+          key: v1-kmk-lint-{{ checksum "Pipfile.lock" }}
+          paths:
+            - .venv
+
+workflows:
+  version: 2
+  build-deploy:
+    jobs:
+      - lint:
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-exclude = .git,__pycache__,vendor
+exclude = .git,__pycache__,vendor,.venv
 max_line_length = 99
 
 [isort]


### PR DESCRIPTION
This will fail and block a merge on a PR if the linter fails (checks for all the normal Flake8 stuff, plus verifying that `[]{}()` literals are used instead of, say, `dict(...)`, plus verifying that all imports are sorted correctly (which can be fixed locally automatically with `pipenv run isort myfile.py`)

I'll be configuring GitHub to require the lint step for inbound PRs to be mergeable.